### PR TITLE
Added a fix to deal with leading slash in page.url.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,15 +2,15 @@
 <ul id='links'>
   {% for post in site.posts %}
     {% if post.category == null %}
-    <li><a href='#{{ post.url }}'>{{ post.title }}</a></li>
+    <li><a href='#{{ post.url | remove:'/' }}'>{{ post.title }}</a></li>
     {% endif %}
   {% endfor %}
   {% for category in site.categories %}
   <li><h2>{{ category | first }}</h2>
     <ul>
     {% for posts in category %}
-      {% for post in posts %}        
-        <li class='{{ post.type }}'><a href='#{{ post.url }}'>{{ post.title }}</a></li>
+      {% for post in posts %}
+        <li class='{{ post.type }}'><a href='#{{ post.url | remove:'/' }}'>{{ post.title }}</a></li>
       {% endfor %}
     {% endfor %}
     </ul>

--- a/assets.js
+++ b/assets.js
@@ -3853,7 +3853,7 @@ if ( !jQuery.support.submitBubbles ) {
 			});
 			// return undefined since we don't need an event listener
 		},
-		
+
 		postDispatch: function( event ) {
 			// If form was submitted by the user, bubble the event up the tree
 			if ( event._submit_bubble ) {
@@ -9629,12 +9629,12 @@ $.expr[':'].Contains = function(a,i,m){
  */
 function Filter(list) {
     this.el = list;
-    
+
     // Filter input
     var form = $('<form>').attr({ 'action':'#' });
     var input = $('<input>').attr({ 'type':'text', 'placeholder':'Filter by keyword' });
     $(form).append(input).prependTo(this.el);
-    
+
     // Filter function
     var self = this;
     $(input).change(function () {
@@ -9645,7 +9645,7 @@ function Filter(list) {
         } else {
             $(self.el).find('li').show();
         }
-        
+
         // Hide titles when group is empty
         $(self.el).find('ul').each(function () {
             if (!$(this).find('li:visible').length) {
@@ -9658,7 +9658,7 @@ function Filter(list) {
         return false;
     })
     .keyup( function () { $(this).change(); });
-    
+
     return this;
 }
 });
@@ -9692,7 +9692,7 @@ $('#sidebar a').each(function () {
     });
 
     // If we find a link in the body with similar anchor, add the same behavior
-    $('.body a[href=#'+ id +']').click(function (e) {
+    $('.body a[name=#'+ id +']').click(function (e) {
         $('#sidebar a[href=#'+ id +']').trigger('click');
     });
 });
@@ -9700,13 +9700,13 @@ $('#sidebar a').each(function () {
 // Hide all/Show all links
 var show = $('<a class=\'control show\'>Show all</a>');
 show.click(function () {
-  $('#content article:not(".active") > a').trigger('click');    
+  $('#content article:not(".active") > a').trigger('click');
 });
 $('#content').prepend(show);
 
 var hide = $('<a class=\'control hide\'>Hide all</a>');
 hide.click(function () {
-  $('#content article.active > a').trigger('click');    
+  $('#content article.active > a').trigger('click');
 });
 $('#content').prepend(hide);
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
 <section id='content'>
 {% for post in site.posts %}
   <article class='{{ post.type }}'>
-    <a name='{{ post.url }}' href='#{{ post.url }}'><h2>{% if post.type %}<code><b>{{ post.type }}</b> {{ post.path }}</code> {% endif %}{{ post.title }}</h2></a>
+    <a name='{{ post.url | remove:'/' }}' href='#{{ post.url }}'><h2>{% if post.type %}<code><b>{{ post.type }}</b> {{ post.path }}</code> {% endif %}{{ post.title }}</h2></a>
     <section class='body'>
       {{ post.content }}
     </section>


### PR DESCRIPTION
I was having problems with a leading slash in page.url and some of the selectors. It didn't like selectors that look like: `#/foo`. I simply stripped all forward slashes in the side nav anchors and the article anchors to get around the problem.
