### PR TITLE
Removes empty element in category post loop

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,10 +8,8 @@
   {% for category in site.categories %}
   <li><h2>{{ category | first }}</h2>
     <ul>
-    {% for posts in category %}
-      {% for post in posts %}        
-        <li class='{{ post.type }}'><a href='#{{ post.url }}'>{{ post.title }}</a></li>
-      {% endfor %}
+    {% for post in category.last %}
+      <li class='{{ post.type }}'><a href='#{{ post.url }}'>{{ post.title }}</a></li>
     {% endfor %}
     </ul>
   </li>


### PR DESCRIPTION
With the old post loop, an empty `<li></li>` was being created at the beginning. Using `category.last` to reference the array of posts fixes this.
