### PR TITLE
Clears the 'highlighter' deprecation error when you start your Jekyll server

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 ---
 exclude: ['README.markdown']
 permalink: ':title'
-pygments: true
+highlighter: pygments
 safe: false
 title: 'Carte'


### PR DESCRIPTION
Just cleaning this config up slightly.
